### PR TITLE
Set font-family to 'monospace'

### DIFF
--- a/styles/shCore.css
+++ b/styles/shCore.css
@@ -46,7 +46,7 @@
   vertical-align: baseline !important;
   width: auto !important;
   box-sizing: content-box !important;
-  font-family: "Consolas", "Bitstream Vera Sans Mono", "Courier New", Courier, monospace !important;
+  font-family: monospace !important;
   font-weight: normal !important;
   font-style: normal !important;
   font-size: 1em !important;


### PR DESCRIPTION
I set the font family for the code to 'monospace' and removed all other font faces from the list. I think that the font face should always be the one that the user chose in the Chrome preferences.
