### PR TITLE
Add an option to disable double-click text selection

### DIFF
--- a/background.coffee
+++ b/background.coffee
@@ -11,6 +11,7 @@ SyntaxticSettings = () ->
   _fontFamily = localStorage["syntaxtic.settings.fontFamily"]
   _gutterBlacklist = JSON.parse(localStorage["syntaxtic.settings.gutterBlacklist"])
   _highlightBlacklist = JSON.parse(localStorage["syntaxtic.settings.highlightBlacklist"])
+  _disableQuickCode = localStorage["syntaxtic.settings.disableQuickCode"]
 
   _defaultTheme = "shThemeMidnight.css"
   _defaultFontSize = "normal"
@@ -56,6 +57,15 @@ SyntaxticSettings = () ->
   this.__defineSetter__("highlightBlacklist", (val) ->
     _highlightBlacklist = val
     localStorage["syntaxtic.settings.highlightBlacklist"] = JSON.stringify(val)
+  )
+
+  this.__defineGetter__("disableQuickCode", ->
+    val = localStorage["syntaxtic.settings.disableQuickCode"] || (_disableQuickCode || false)
+    return val == "true"
+  )
+  this.__defineSetter__("disableQuickCode", (val) ->
+    _disableQuickCode = val
+    localStorage["syntaxtic.settings.disableQuickCode"] = val
   )
 
 

--- a/content_script.coffee
+++ b/content_script.coffee
@@ -38,9 +38,12 @@ syntaxtic =
     highlight = () ->
       if !document.body.innerHTML.match("003ew0hdafa1119dadfa39aje")
         if document.body.firstChild != null && document.getElementsByTagName('pre')[0] == document.body.firstChild
+          classString = "brush: #{window.brushAlias}"
+          if settings.disableQuickCode
+            classString += "; quick-code: false"
           document.body.innerHTML = """
             <!-- 003ew0hdafa1119dadfa39aje -->
-            <script type="syntaxhighlighter" class="brush: #{window.brushAlias}">
+            <script type="syntaxhighlighter" class="#{classString}">
               <![CDATA[#{document.body.firstChild.innerHTML}]]>
             </script>
             """

--- a/options.coffee
+++ b/options.coffee
@@ -37,6 +37,7 @@ optionChanged = () ->
   settings.theme = document.getElementById('themeSelect').value
   settings.fontSize = document.getElementById('fontSizeSelect').value
   settings.fontFamily = document.getElementById('fontFamilySelect').value
+  settings.disableQuickCode = document.getElementById('quickCodeSelect').value
 
   # apply changed theme
   document.getElementById('theme-style').href = chrome.extension.getURL("styles/" + settings.theme)
@@ -54,6 +55,7 @@ initOptionsPage = () ->
   document.getElementById('themeSelect').value = settings.theme
   document.getElementById('fontSizeSelect').value = settings.fontSize
   document.getElementById('fontFamilySelect').value = settings.fontFamily
+  document.getElementById('quickCodeSelect').value = settings.disableQuickCode
 
 document.addEventListener 'DOMContentLoaded', () ->
 

--- a/options.html
+++ b/options.html
@@ -31,6 +31,8 @@
 			<div class="line number21 index20 alt2">21</div>
 			<div class="line number22 index21 alt1">22</div>
 			<div class="line number23 index22 alt2">23</div>
+			<div class="line number24 index23 alt1">24</div>
+			<div class="line number25 index24 alt2">25</div>
 		</td>
 		<td class="code"><div class="container">
 			<div class="line number3 index2 alt2"><code class="csharp comments">/***********************************************************************************************</code></div>
@@ -69,7 +71,7 @@
 					<option value="x-large">Really Big</option>
 					<option value="xx-large">Gargantuan</option>
 				</select><code class="csharp plain">;</code></div>
-			<div class="line number20 index19 alt1"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code><code class="csharp keyword">var</code> <code class="csharp plain">fontFamily = </code><select id=fontFamilySelect name=fontFamilySelect >
+			<div class="line number21 index20 alt2"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code><code class="csharp keyword">var</code> <code class="csharp plain">fontFamily = </code><select id=fontFamilySelect name=fontFamilySelect >
 					<option value="Consolas">Consolas</option>
 					<option value="Bitstream Vera Sans Mono">Bitstream Vera Sans Mono</option>
 					<option value="Source Code Pro">Source Code Pro</option>
@@ -79,10 +81,14 @@
 					<option value="Times New Roman">Times New Roman</option>
 					<option value="Georgia">Georgia</option>
 				</select><code class="csharp plain">;</code></div>
-			<div class="line number20 index19 alt1"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code><code class="csharp keyword">Console</code><code class="csharp plain">.WriteLine(</code><code class="csharp value">"Syntaxtic! settings now configured."</code><code class="csharp plain">);</code></div>
-			<div class="line number21 index20 alt2"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code><code class="csharp plain">}</code></div>
-			<div class="line number22 index21 alt1"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;</code><code class="csharp plain">}</code></div>
-			<div class="line number22 index21 alt1"><code class="csharp spaces">&nbsp;</code><code class="csharp plain">}</code></div>
+			<div class="line number22 index21 alt1"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code><code class="csharp keyword">var</code> <code class="csharp plain">quickCode = </code><select id=quickCodeSelect name=quickCodeSelect >
+				<option value="false">Enabled</option>
+				<option value="true">Disabled</option>
+			</select><code class="csharp plain">;</code></div>
+			<div class="line number23 index22 alt1"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code><code class="csharp keyword">Console</code><code class="csharp plain">.WriteLine(</code><code class="csharp value">"Syntaxtic! settings now configured."</code><code class="csharp plain">);</code></div>
+			<div class="line number24 index23 alt2"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code><code class="csharp plain">}</code></div>
+			<div class="line number25 index24 alt1"><code class="csharp spaces">&nbsp;&nbsp;&nbsp;</code><code class="csharp plain">}</code></div>
+			<div class="line number26 index25 alt1"><code class="csharp spaces">&nbsp;</code><code class="csharp plain">}</code></div>
 		</div></td>
 		</tr>
 		</tbody>


### PR DESCRIPTION
Added an option to disable SyntaxHighlighter's `quickCode` setting.